### PR TITLE
fix: 修复获取字典参数为空时的判断条件

### DIFF
--- a/continew-admin-ui/src/store/modules/dict/index.ts
+++ b/continew-admin-ui/src/store/modules/dict/index.ts
@@ -6,7 +6,7 @@ const useDictStore = defineStore('dict', {
   actions: {
     // 获取字典
     getDict(_name: string) {
-      if (_name === null && _name === '') {
+      if (_name == null || _name === '') {
         return null;
       }
       try {


### PR DESCRIPTION
<!--
  非常感谢您的 PR！在提交之前，请务必确保您 PR 的代码经过了完整测试，并且通过了代码规范检查。
-->

## PR 类型

- [ ] 新 feature
- [x] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [ ] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [ ] 其他

## PR 目的

修复获取字典参数为空时的判断条件。

## 解决方案

```js
if (_name == null || _name === '')
```

## PR 测试

无

## Changelog

| 模块  | Changelog | Related issues |
|-----|-----------| -------------- |
|   前端（公共字典）  |     修复获取字典参数为空时的判断条件      |        无        |

## 其他信息

无

## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [x] 已经完整填写 Changelog，并链接到了相关 issues
- [x] PR 代码将要提交到 dev 分支