### PR TITLE
fix: 修复查询数据库表按修改时间排序时，修改时间为空导致的 NPE 问题

### DIFF
--- a/continew-admin-tool/src/main/java/top/charles7c/cnadmin/tool/service/impl/GeneratorServiceImpl.java
+++ b/continew-admin-tool/src/main/java/top/charles7c/cnadmin/tool/service/impl/GeneratorServiceImpl.java
@@ -19,10 +19,7 @@ package top.charles7c.cnadmin.tool.service.impl;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -91,7 +88,9 @@ public class GeneratorServiceImpl implements GeneratorService {
         }
         tableList.removeIf(table -> StrUtil.equalsAny(table.getTableName(), generatorProperties.getExcludeTables()));
         CollUtil.sort(tableList,
-            Comparator.comparing(Table::getCreateTime).thenComparing(Table::getUpdateTime).reversed());
+            Comparator.comparing(Table::getCreateTime)
+                .thenComparing(table -> Optional.ofNullable(table.getUpdateTime()).orElse(table.getCreateTime()))
+                .reversed());
         List<TableVO> tableVOList = BeanUtil.copyToList(tableList, TableVO.class);
         PageDataVO<TableVO> pageDataVO = PageDataVO.build(pageQuery.getPage(), pageQuery.getSize(), tableVOList);
         for (TableVO tableVO : pageDataVO.getList()) {


### PR DESCRIPTION
## PR 类型

- [ ] 新 feature
- [x] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [ ] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [ ] 其他

## PR 目的

修复查询数据库表按修改时间排序时，修改时间为空导致的 NPE 问题

## 解决方案

使用 Java Optional 类避免此空指针异常

## PR 测试

无

## Changelog

| 模块  | Changelog | Related issues |
|-----|-----------| -------------- |
|  系统工具模块（后端） | 修复查询数据库表按修改时间排序时，修改时间为空导致的 NPE 问题  |         无      |


## 其他信息

无

## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [x] 已经完整填写 Changelog，并链接到了相关 issues
- [x] PR 代码将要提交到 dev 分支