### PR TITLE
feat:角色管理增加关联用户功能

### DIFF
--- a/continew-admin-common/src/main/java/top/continew/admin/common/constant/SysConstants.java
+++ b/continew-admin-common/src/main/java/top/continew/admin/common/constant/SysConstants.java
@@ -38,6 +38,14 @@ public class SysConstants {
      * 管理员角色编码
      */
     public static final String ADMIN_ROLE_CODE = "admin";
+    /**
+     * 超管角色组ID
+     */
+    public static final Long SUPER_ROLE_ID = 1L;
+    /**
+     * 超管账号ID
+     */
+    public static final Long SUPER_ADMIN_ID = 1L;
 
     /**
      * 顶级部门 ID

--- a/continew-admin-system/src/main/java/top/continew/admin/system/service/DeptService.java
+++ b/continew-admin-system/src/main/java/top/continew/admin/system/service/DeptService.java
@@ -16,11 +16,13 @@
 
 package top.continew.admin.system.service;
 
+import cn.hutool.core.lang.tree.Tree;
 import top.continew.admin.system.model.entity.DeptDO;
 import top.continew.admin.system.model.query.DeptQuery;
 import top.continew.admin.system.model.req.DeptReq;
 import top.continew.admin.system.model.resp.DeptResp;
 import top.continew.starter.data.mp.service.IService;
+import top.continew.starter.extension.crud.model.query.SortQuery;
 import top.continew.starter.extension.crud.service.BaseService;
 
 import java.util.List;
@@ -56,4 +58,14 @@ public interface DeptService extends BaseService<DeptResp, DeptResp, DeptQuery, 
      * @return 部门数量
      */
     int countByNames(List<String> deptNames);
+
+    /**
+     * 部门用户树
+     *
+     * @param query 部门查询条件
+     * @param sortQuery 排序条件
+     * @param isSimple 是否只返回简单部门树
+     * @return 部门数量
+     */
+    List<Tree<String>> treeWithUsers(DeptQuery query, SortQuery sortQuery, boolean isSimple);
 }

--- a/continew-admin-system/src/main/java/top/continew/admin/system/service/UserRoleService.java
+++ b/continew-admin-system/src/main/java/top/continew/admin/system/service/UserRoleService.java
@@ -16,6 +16,7 @@
 
 package top.continew.admin.system.service;
 
+import top.continew.admin.system.model.entity.UserDO;
 import top.continew.admin.system.model.entity.UserRoleDO;
 
 import java.util.List;
@@ -38,6 +39,14 @@ public interface UserRoleService {
     boolean add(List<Long> roleIds, Long userId);
 
     /**
+     * 关联用户
+     *
+     * @param roleId 角色id
+     * @param userIds 用户id列表
+     * @return 是否新增成功（true：成功；false：无变更/失败）
+     */
+    boolean bindUserIds(Long roleId,List<Long> userIds);
+    /**
      * 根据用户 ID 删除
      *
      * @param userIds 用户 ID 列表
@@ -50,6 +59,8 @@ public interface UserRoleService {
      * @param list 数据集
      */
     void saveBatch(List<UserRoleDO> list);
+
+
 
     /**
      * 根据用户 ID 查询
@@ -74,4 +85,5 @@ public interface UserRoleService {
      * @return 是否已关联（true：已关联；false：未关联）
      */
     boolean isRoleIdExists(List<Long> roleIds);
+
 }

--- a/continew-admin-system/src/main/java/top/continew/admin/system/service/impl/RoleServiceImpl.java
+++ b/continew-admin-system/src/main/java/top/continew/admin/system/service/impl/RoleServiceImpl.java
@@ -36,6 +36,7 @@ import top.continew.admin.common.context.UserContextHolder;
 import top.continew.admin.common.enums.DataScopeEnum;
 import top.continew.admin.system.mapper.RoleMapper;
 import top.continew.admin.system.model.entity.RoleDO;
+import top.continew.admin.system.model.entity.UserDO;
 import top.continew.admin.system.model.query.RoleQuery;
 import top.continew.admin.system.model.req.RoleReq;
 import top.continew.admin.system.model.resp.MenuResp;
@@ -197,6 +198,8 @@ public class RoleServiceImpl extends BaseServiceImpl<RoleMapper, RoleDO, RoleRes
         }
         return (int)this.count(Wrappers.<RoleDO>lambdaQuery().in(RoleDO::getName, roleNames));
     }
+
+
 
     /**
      * 名称是否存在

--- a/continew-admin-webapi/src/main/java/top/continew/admin/controller/common/CommonController.java
+++ b/continew-admin-webapi/src/main/java/top/continew/admin/controller/common/CommonController.java
@@ -80,6 +80,12 @@ public class CommonController {
         return deptService.tree(query, sortQuery, true);
     }
 
+    @Operation(summary = "查询部门用户树", description = "查询树结构的部门列表")
+    @GetMapping("/tree/deptWithUsers")
+    public List<Tree<String>> listDeptWithUsersTree(DeptQuery query, SortQuery sortQuery) {
+        return deptService.treeWithUsers(query, sortQuery, true);
+    }
+
     @Operation(summary = "查询菜单树", description = "查询树结构的菜单列表")
     @GetMapping("/tree/menu")
     public List<Tree<Long>> listMenuTree(MenuQuery query, SortQuery sortQuery) {

--- a/continew-admin-webapi/src/main/java/top/continew/admin/controller/system/RoleController.java
+++ b/continew-admin-webapi/src/main/java/top/continew/admin/controller/system/RoleController.java
@@ -16,18 +16,27 @@
 
 package top.continew.admin.controller.system;
 
+import cn.dev33.satoken.annotation.SaCheckPermission;
+import cn.hutool.core.lang.tree.Tree;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-import org.springframework.web.bind.annotation.RestController;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
 
+import top.continew.admin.system.model.query.DeptQuery;
 import top.continew.admin.system.model.query.RoleQuery;
 import top.continew.admin.system.model.req.RoleReq;
 import top.continew.admin.system.model.resp.RoleDetailResp;
 import top.continew.admin.system.model.resp.RoleResp;
 import top.continew.admin.system.service.RoleService;
+import top.continew.admin.system.service.UserRoleService;
 import top.continew.starter.extension.crud.annotation.CrudRequestMapping;
 import top.continew.starter.extension.crud.controller.BaseController;
 import top.continew.starter.extension.crud.enums.Api;
+import top.continew.starter.extension.crud.model.query.SortQuery;
+
+import java.util.List;
 
 /**
  * 角色管理 API
@@ -37,6 +46,22 @@ import top.continew.starter.extension.crud.enums.Api;
  */
 @Tag(name = "角色管理 API")
 @RestController
+@RequiredArgsConstructor
 @CrudRequestMapping(value = "/system/role", api = {Api.PAGE, Api.GET, Api.ADD, Api.UPDATE, Api.DELETE})
 public class RoleController extends BaseController<RoleService, RoleResp, RoleDetailResp, RoleQuery, RoleReq> {
+
+    private final UserRoleService userRoleService;
+
+    @Operation(summary = "查询角色关联用户", description = "查询角色组绑定的关联用户")
+    @GetMapping("/listRoleUsers/{id}")
+    public List<Long> listUsers(@PathVariable("id") Long roleId) {
+        return userRoleService.listUserIdByRoleId(roleId);
+    }
+
+    @Operation(summary = "关联用户", description = "批量关联用户")
+    @SaCheckPermission("system:role:bindUsers")
+    @PostMapping("/bindUsers/{id}")
+    public void bindUsers(@PathVariable("id") Long roleId,@RequestBody List<Long> userIds) {
+        userRoleService.bindUserIds(roleId, userIds);
+    }
 }


### PR DESCRIPTION
增加权限校验

<!--
  非常感谢您的 PR！在提交之前，请务必确保您 PR 的代码经过了完整测试，并且通过了代码规范检查。
-->

<!-- 在 [] 中输入 x 来勾选) -->

## PR 类型

<!-- 您的 PR 引入了哪种类型的变更？ -->
<!-- 只支持选择一种类型，如果有多种类型，可以在更新日志中增加 “类型” 列。 -->

- [x] 新 feature
- [ ] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [ ] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [ ] 其他

## PR 目的

角色管理页面增加操作按钮 关联用户

## 解决方案
前端增加 关联界面，增加了3个接口
1）获取部门用户树 (由于部门与用户树 部分数据id存在冲突，所以在树的key单独增加了前缀区分避免树形组件由于key相同时选中)
2)  获取已绑定的用户列表
3）绑定用户

## PR 测试
<img width="1247" alt="list" src="https://github.com/user-attachments/assets/9a1a0252-d601-4c79-8406-73fdca5584b8">

## Changelog

| 模块  | Changelog | Related issues |
|-----|-----------| -------------- |
|common| 增加2个常量 ||
|system|获取部门用户树、关联用户||
|webapi|用户树、查看已绑定用户、绑定用户接口||

## 其他信息


## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [x] 已经完整填写 Changelog，并链接到了相关 issues
- [x] PR 代码将要提交到 dev 分支