### PR TITLE
fix: 升级依赖容器jdk版本为openjdk:21

### DIFF
--- a/docker/continew-admin/Dockerfile
+++ b/docker/continew-admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:21
 
 MAINTAINER Charles7c charles7c@126.com
 

--- a/docker/schedule-server/Dockerfile
+++ b/docker/schedule-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17
+FROM openjdk:21
 
 MAINTAINER Charles7c charles7c@126.com
 


### PR DESCRIPTION
<!--
  非常感谢您的 PR！在提交之前，请务必确保您 PR 的代码经过了完整测试，并且通过了代码规范检查。
-->

<!-- 在 [] 中输入 x 来勾选) -->

## PR 类型

<!-- 您的 PR 引入了哪种类型的变更？ -->
<!-- 只支持选择一种类型，如果有多种类型，可以在更新日志中增加 “类型” 列。 -->

- [ ] 新 feature
- [x] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [ ] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [ ] 其他

## PR 目的

#145 

## 解决方案

升级依赖容器jdk版本为openjdk:21。
原因是openjdk:17容器所依赖的linux内核导致运行jdk会出现#145问题，升级成其他版本就可以

## PR 测试



## Changelog

| 模块  | Changelog | Related issues |
|-----|-----------| -------------- |
|   docker  |      升级openjdk版本为21     |   #145              |


## 其他信息


## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [x] 已经完整填写 Changelog，并链接到了相关 issues
- [x] PR 代码将要提交到 dev 分支