### PR TITLE
添加docker-compose-dev.yml配置统一开发环境的搭建

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ build/
 *.diff
 *.patch
 *.tmp
+# mysql和redis的持久化文件、日志文件
+data
+log

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -19,9 +19,9 @@ services:
       #MYSQL_USER: 你的数据库用户名
       #MYSQL_PASSWORD: 你的数据库密码
     volumes:
-      - /docker/mysql/conf/:/etc/mysql/conf.d/
-      - /docker/mysql/data/:/var/lib/mysql/
-      - /docker/mysql/log:/var/log/mysql # mysql 日志目录
+      - ./mysql/conf/:/etc/mysql/conf.d/
+      - ./mysql/data/:/var/lib/mysql/
+      - ./mysql/logs:/var/log/mysql # mysql 日志目录
       #- ../sql/mysql8:/docker-entrypoint-initdb.d # 初始化 SQL 脚本目录
     command:
       --default-authentication-plugin=mysql_native_password
@@ -53,27 +53,10 @@ services:
     environment:
       TZ: Asia/Shanghai
     volumes:
-      - /docker/redis/conf/redis.conf:/usr/local/redis/config/redis.conf
-      - /docker/redis/data/:/data/
-      - /docker/redis/logs/:/logs/
+      - ./redis/conf/redis.conf:/usr/local/redis/config/redis.conf
+      - ./redis/data/:/data/
+      - ./redis/logs/:/logs/
     command: redis-server /usr/local/redis/config/redis.conf --appendonly yes --requirepass 123456
     networks:
       - continew  # 加入 continew 网络
 
-  nginx:
-    image: nginx:1.25.3
-    restart: always
-    container_name: nginx
-    ports:
-      - '80:80'
-      - '443:443'
-    environment:
-      TZ: Asia/Shanghai
-    volumes:
-      - /docker/nginx/conf/:/etc/nginx/
-      - /docker/nginx/cert/:/etc/nginx/cert/
-      - /docker/nginx/logs/:/var/log/nginx/
-      # 前端页面目录
-      - /docker/continew-admin/html/:/usr/share/nginx/html/
-    networks:
-      - continew  # 加入 continew 网络

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -15,14 +15,14 @@ services:
       LANG: en_US.UTF-8
       MYSQL_ROOT_PASSWORD: 123456  # 你的 root 用户密码
       # 初始化数据库（后续的初始化 SQL 会在这个库执行）
-      MYSQL_DATABASE: continew_admin
+      # MYSQL_DATABASE: continew_admin
       #MYSQL_USER: 你的数据库用户名
       #MYSQL_PASSWORD: 你的数据库密码
     volumes:
       - ./mysql/conf/:/etc/mysql/conf.d/
       - ./mysql/data/:/var/lib/mysql/
       - ./mysql/logs:/var/log/mysql # mysql 日志目录
-      #- ../sql/mysql8:/docker-entrypoint-initdb.d # 初始化 SQL 脚本目录
+      - ./mysql/sql:/docker-entrypoint-initdb.d # 初始化 SQL 脚本目录
     command:
       --default-authentication-plugin=mysql_native_password
       --character-set-server=utf8mb4

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,0 +1,79 @@
+# 创建一个continew的桥接网络
+networks:
+  continew:
+    driver: bridge
+
+services:
+  mysql:
+    image: mysql:8.0.33
+    restart: always
+    container_name: mysql8.0.33
+    ports:
+      - '3306:3306'
+    environment:
+      TZ: Asia/Shanghai
+      LANG: en_US.UTF-8
+      MYSQL_ROOT_PASSWORD: 123456  # 你的 root 用户密码
+      # 初始化数据库（后续的初始化 SQL 会在这个库执行）
+      MYSQL_DATABASE: continew_admin
+      #MYSQL_USER: 你的数据库用户名
+      #MYSQL_PASSWORD: 你的数据库密码
+    volumes:
+      - /docker/mysql/conf/:/etc/mysql/conf.d/
+      - /docker/mysql/data/:/var/lib/mysql/
+      - /docker/mysql/log:/var/log/mysql # mysql 日志目录
+      #- ../sql/mysql8:/docker-entrypoint-initdb.d # 初始化 SQL 脚本目录
+    command:
+      --default-authentication-plugin=mysql_native_password
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_general_ci
+      --explicit_defaults_for_timestamp=true
+      --lower_case_table_names=1
+    networks:
+        - continew  # 加入 continew 网络
+#  postgresql:
+#    image: postgres:14.2
+#    restart: always
+#    container_name: postgresql
+#    ports:
+#      - '5432:5432'
+#    environment:
+#      TZ: Asia/Shanghai
+#      POSTGRES_USER: 你的用户名
+#      POSTGRES_PASSWORD: 你的用户密码
+#      POSTGRES_DB: continew_admin
+#    volumes:
+#      - /docker/postgresql/data/:/var/lib/postgresql/data/
+  redis:
+    image: redis:7.2.3
+    restart: always
+    container_name: redis7.2.3
+    ports:
+      - '6379:6379'
+    environment:
+      TZ: Asia/Shanghai
+    volumes:
+      - /docker/redis/conf/redis.conf:/usr/local/redis/config/redis.conf
+      - /docker/redis/data/:/data/
+      - /docker/redis/logs/:/logs/
+    command: redis-server /usr/local/redis/config/redis.conf --appendonly yes --requirepass 123456
+    networks:
+      - continew  # 加入 continew 网络
+
+  nginx:
+    image: nginx:1.25.3
+    restart: always
+    container_name: nginx
+    ports:
+      - '80:80'
+      - '443:443'
+    environment:
+      TZ: Asia/Shanghai
+    volumes:
+      - /docker/nginx/conf/:/etc/nginx/
+      - /docker/nginx/cert/:/etc/nginx/cert/
+      - /docker/nginx/logs/:/var/log/nginx/
+      # 前端页面目录
+      - /docker/continew-admin/html/:/usr/share/nginx/html/
+    networks:
+      - continew  # 加入 continew 网络

--- a/docker/mysql/conf/my.cnf
+++ b/docker/mysql/conf/my.cnf
@@ -1,0 +1,45 @@
+# 服务端参数配置
+[mysqld]
+skip-name-resolve
+user=mysql                     # MySQL启动用户
+default-storage-engine=INNODB  # 创建新表时将使用的默认存储引擎
+character-set-server=utf8mb4   # 设置mysql服务端默认字符集
+collation-server = utf8mb4_general_ci # 数据库字符集对应一些排序等规则，注意要和character-set-server对应
+
+pid-file        = /var/lib/mysql/mysqld.pid  # pid文件所在目录
+socket          = /var/lib/mysql/mysqld.sock # 用于本地连接的socket套接字
+datadir         = /var/lib/mysql             # 数据文件存放的目录
+bind-address    = 127.0.0.1                  # MySQL绑定IP
+expire_logs_days= 7                          # 定义清除过期日志的时间(这里设置为7天)
+
+slow_query_log = ON                            # 开启慢查询日志
+slow_query_log_file = /var/log/mysql/slow.log  # 慢查询日志文件路径
+long_query_time = 0.5                          # 慢查询时间，单位为秒，0.5秒以上的查询将被记录到慢查询日志中
+
+# 设置client连接mysql时的字符集,防止乱码
+init_connect='SET NAMES utf8mb4'
+
+# 是否对sql语句大小写敏感，1表示不敏感
+lower_case_table_names = 1
+
+# 执行sql的模式，规定了sql的安全等级, 暂时屏蔽，my.cnf文件中配置报错
+#sql_mode = STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
+
+# 事务隔离级别，默认为可重复读，mysql默认可重复读级别（此级别下可能参数很多间隙锁，影响性能）
+transaction_isolation = READ-COMMITTED
+
+# TIMESTAMP如果没有显示声明NOT NULL，允许NULL值
+explicit_defaults_for_timestamp = true
+
+#它控制着mysqld进程能使用的最大文件描述(FD)符数量。
+#需要注意的是这个变量的值并不一定是你设定的值，mysqld会在系统允许的情况下尽量获取更多的FD数量
+open_files_limit    = 65535
+
+# 允许最大连接数
+max_connections=200
+
+#最大错误连接数
+max_connect_errors = 1000
+
+[client]
+default-character-set=utf8mb4  # 设置mysql客户端默认字符集

--- a/docker/mysql/sql/01_create_database.sql
+++ b/docker/mysql/sql/01_create_database.sql
@@ -1,0 +1,10 @@
+-- ----------------------------
+-- 创建continew_admin数据库
+-- ----------------------------
+drop database if exists `continew_admin`;
+create database `continew_admin` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+-- ----------------------------
+-- 创建continew_admin_job数据库
+-- ----------------------------
+drop database if exists `continew_admin_job`;
+create database `continew_admin_job` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;

--- a/docker/redis/conf/redis.conf
+++ b/docker/redis/conf/redis.conf
@@ -1,6 +1,6 @@
 bind 0.0.0.0
 # redis 密码
-requirepass 你的 Redis 密码
+#requirepass 你的 Redis 密码
 
 # key 监听器配置
 # notify-keyspace-events Ex

--- a/docker/run.md
+++ b/docker/run.md
@@ -1,0 +1,12 @@
+# 开发环境配置
+
+## 安装以及启动
+
+```bash
+docker-compose -f docker-compose-dev.yml -p continew-admin up -d
+```
+## 卸载
+```bash
+docker-compose -f docker-compose-dev.yml -p continew-admin down
+```
+


### PR DESCRIPTION


## PR 类型

- [ ] 新 feature
- [ ] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [ ] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [x] 其他

## PR 目的

统一开发环境的搭建，便于开发测试

## 解决方案

新增一个docker-compose-dev.yml的配置，以及mysql和redis的配置文件，用于docker创建、启动mysql和redis服务，还增加了一键创建和删除开发环境的脚本命令。

开发使用方式：

- 安装[docker desktop](https://www.docker.com/products/docker-desktop/)(可选)
- 在linux服务器或者直接运行[docker/run.md](docker/run.md)(如果已经安装了docker desktop)中的如下命令：

  ```bash
  cd docker
  docker-compose -f docker-compose-dev.yml -p continew-admin up -d
  ```

！！！在IDEA中，如果安装了bash插件可以直接在run.md中直接运行这段命令搭建开发环境

## PR 测试



## Changelog

| 模块  | Changelog | Related issues |
|-----|-----------| -------------- |
|     |           |                |

## 其他信息

## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [ ] 已经完整填写 Changelog，并链接到了相关 issues
- [x] PR 代码将要提交到 dev 分支