### PR TITLE
fix(file): 添加上传源对象规范化处理，支持将 File 转换为 EnhancedMultipartFile

### DIFF
--- a/continew-system/src/main/java/top/continew/admin/system/service/impl/FileServiceImpl.java
+++ b/continew-system/src/main/java/top/continew/admin/system/service/impl/FileServiceImpl.java
@@ -26,6 +26,7 @@ import jakarta.annotation.Resource;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -54,10 +55,12 @@ import top.continew.starter.core.util.validation.CheckUtils;
 import top.continew.starter.core.util.validation.ValidationUtils;
 import top.continew.starter.storage.core.FileStorageService;
 import top.continew.starter.storage.core.UploadPretreatment;
+import top.continew.starter.storage.domain.file.EnhancedMultipartFile;
 import top.continew.starter.storage.domain.model.resp.FileInfo;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
@@ -281,7 +284,7 @@ public class FileServiceImpl extends BaseServiceImpl<FileMapper, FileDO, FileRes
             this.saveUploadProgress(normalizedUploadTaskId, FileUploadProgressStatusEnum.INIT, 0L, totalBytes, 0, null, null, null);
         }
 
-        UploadPretreatment uploadPretreatment = fileStorageService.of(file)
+        UploadPretreatment uploadPretreatment = fileStorageService.of(normalizeUploadSource(file))
             .platform(storage.getCode())
             .path(this.pretreatmentPath(parentPath))
             .fileName(uniqueFileName)
@@ -335,6 +338,33 @@ public class FileServiceImpl extends BaseServiceImpl<FileMapper, FileDO, FileRes
             return ioFile.getName();
         }
         return "unknown";
+    }
+
+    /**
+     * 规范化上传源对象。
+     *
+     * <p>
+     * 如果传入的是 {@link File}，则先读取文件内容并包装为 {@link EnhancedMultipartFile}，
+     * 避免 starter-storage 将其按普通对象走 JSON 分支处理；其他类型保持原样返回。
+     * </p>
+     *
+     * @param file 上传源对象
+     * @return 可交给 starter-storage 处理的上传对象
+     */
+    private static Object normalizeUploadSource(Object file) {
+        if (!(file instanceof File ioFile)) {
+            return file;
+        }
+        try {
+            String contentType = Files.probeContentType(ioFile.toPath());
+            if (StrUtil.isBlank(contentType)) {
+                contentType = MediaType.APPLICATION_OCTET_STREAM_VALUE;
+            }
+            return EnhancedMultipartFile.create(ioFile.getName(), ioFile.getName(), contentType, Files.readAllBytes(ioFile
+                .toPath()));
+        } catch (IOException e) {
+            throw new IllegalStateException("读取上传文件失败", e);
+        }
     }
 
     /**


### PR DESCRIPTION
## PR 类型

- [ ] 新 feature
- [x] Bug 修复
- [ ] 功能增强
- [ ] 文档变更
- [ ] 代码样式变更
- [ ] 重构
- [ ] 性能改进
- [ ] 单元测试
- [ ] CI/CD
- [ ] 其他

## PR 目的

修复文件上传链路在传入 `java.io.File` 时，底层 `starter-storage` 可能将其按普通对象走 JSON 分支处理，导致本地临时文件无法按真实文件语义上传的问题。

## 解决方案

- 在 `FileServiceImpl` 中新增 `normalizeUploadSource`，对上传源做统一规范化处理。
- 当上传源为 `File` 时，先读取文件内容并包装为 `EnhancedMultipartFile`，显式补齐文件名、`contentType` 和字节内容后再交给 `starter-storage`。
- 非 `File` 类型的上传源保持原样透传，避免影响现有 `MultipartFile` 等调用链路。

## PR 测试

- 覆盖验证点：
  - `java.io.File` 上传源会被转换为 `MultipartFile`
  - 转换后文件名和文件内容保持一致
  - 非 `File` 上传源保持原样返回

## Changelog

| 模块 | Changelog | Related issues |
|-----|-----------|--------------|
| `continew-system` | 修复 `FileServiceImpl` 在处理本地 `File` 上传源时被底层存储组件误判为普通对象的问题，统一转换为 `EnhancedMultipartFile` 后上传 | - |

## 其他信息


## 提交前确认

- [x] PR 代码经过了完整测试，并且通过了代码规范检查
- [ ] 已经完整填写 Changelog，并链接到了相关 issues
- [ ] PR 代码将要提交到 `dev` 分支
