### PR TITLE
fix(tenant): 调整租户关联表索引

### DIFF
--- a/continew-server/src/main/resources/db/changelog/mysql/plugin/plugin_tenant.sql
+++ b/continew-server/src/main/resources/db/changelog/mysql/plugin/plugin_tenant.sql
@@ -142,3 +142,18 @@ VALUES
 (3023, '新增', 3020, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'tenant:package:create', 3, 1, 1, NOW()),
 (3024, '修改', 3020, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'tenant:package:update', 4, 1, 1, NOW()),
 (3025, '删除', 3020, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'tenant:package:delete', 5, 1, 1, NOW());
+
+-- changeset luoqiz:2
+-- comment 调整租户关联表主键及用户角色唯一索引
+ALTER TABLE `sys_user_role`
+    DROP INDEX `idx_tenant_id`,
+    DROP INDEX `uk_user_id_role_id`,
+    ADD UNIQUE INDEX `uk_user_id_role_id` (`tenant_id`, `user_id`, `role_id`);
+ALTER TABLE `sys_role_menu`
+    DROP INDEX `idx_tenant_id`,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (`tenant_id`, `role_id`, `menu_id`);
+ALTER TABLE `sys_role_dept`
+    DROP INDEX `idx_tenant_id`,
+    DROP PRIMARY KEY,
+    ADD PRIMARY KEY (`tenant_id`, `role_id`, `dept_id`);

--- a/continew-server/src/main/resources/db/changelog/postgresql/plugin/plugin_tenant.sql
+++ b/continew-server/src/main/resources/db/changelog/postgresql/plugin/plugin_tenant.sql
@@ -183,3 +183,19 @@ VALUES
 (3024, '修改', 3020, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'tenant:package:update', 4, 1, 1, NOW()),
 (3025, '删除', 3020, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 'tenant:package:delete', 5, 1, 1, NOW());
 
+-- changeset luoqiz:2
+-- comment 调整租户关联表主键及用户角色唯一索引
+DROP INDEX IF EXISTS "idx_user_role_tenant_id";
+DROP INDEX IF EXISTS "idx_role_menu_tenant_id";
+DROP INDEX IF EXISTS "idx_role_dept_tenant_id";
+
+ALTER TABLE "sys_role_menu"
+    DROP CONSTRAINT "sys_role_menu_pkey",
+    ADD CONSTRAINT "sys_role_menu_pkey" PRIMARY KEY ("tenant_id", "role_id", "menu_id");
+ALTER TABLE "sys_role_dept"
+    DROP CONSTRAINT "sys_role_dept_pkey",
+    ADD CONSTRAINT "sys_role_dept_pkey" PRIMARY KEY ("tenant_id", "role_id", "dept_id");
+
+DROP INDEX IF EXISTS "uk_user_id_role_id";
+CREATE UNIQUE INDEX "uk_user_id_role_id" ON "sys_user_role" ("tenant_id", "user_id", "role_id");
+


### PR DESCRIPTION
## 变更类型

- [ ] 新特性（feat）
- [x] 问题修复（fix）
- [ ] 功能优化（refactor / perf / chore / style）
- [ ] 文档变更（docs）
- [ ] 构建、CI 或依赖升级（build / ci）
- [ ] 测试（test）
- [ ] 其他

## 破坏性变更

- [ ] 本 PR 包含破坏性变更（BREAKING CHANGE），已在变更目的中说明影响与迁移方式

## 变更目的

租户插件原有初始化变更集为关联表创建了不包含租户 ID 的主键/唯一索引，可能导致多租户数据之间产生约束冲突。同时，已执行的历史变更集不应被直接改写，需要通过独立增量变更集完成结构调整。

## 解决方案

新增 `changeset luoqiz:2`，并继续追加在 `plugin_tenant.sql` 文件中：

- MySQL 与 PostgreSQL 同步删除关联表上冗余的租户单列索引。
- 将 `sys_role_menu` 和 `sys_role_dept` 的主键调整为包含 `tenant_id` 的复合主键。
- 将 `sys_user_role` 的唯一索引调整为包含 `tenant_id` 的复合唯一索引。
- 保留原 `changeset 1` 不变，确保 Liquibase 按增量方式执行历史数据库升级。

## 测试情况

- 已完成 MySQL/PostgreSQL 两套 SQL 的增量结构核对。
- 已确认变更仅涉及两个 `plugin_tenant.sql` 文件，并通过 `git diff --check`。
- 未执行 `./mvnw verify`：本 PR 仅修改 Liquibase SQL，不涉及 Java 源码或 POM。

## Changelog

| 模块 | Changelog | Related issues |
|------|-----------|----------------|
| tenant | 以增量变更集调整租户关联表复合主键及用户角色唯一索引 | - |

## 提交前确认

- [x] 一个 PR 只解决一个 Issue，不夹带无关改动
- [ ] 本地 `./mvnw verify` 四道门禁全部通过（本 PR 仅修改 SQL，未执行）
- [x] 已完整填写 Changelog（当前无对应 Issue 可关联）
- [x] commit message 符合 [Conventional Commits（约定式提交）](https://www.conventionalcommits.org/zh-hans/v1.0.0/)规范
- [x] 如包含 AI 生成的较大改动，相关 commit 已添加 `Assisted-by: Codex` 标记
- [x] 已签署 [CLA](../blob/dev/CLA.md)（CLA assistant 已确认所有提交者完成签署）
- [x] 目标分支正确：dev（新功能与优化）或 x.x.x 维护分支（仅 Bug 修复）