### PR TITLE
fix: 修复 Sonar 全量分析剩余的可靠性与安全问题

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Remove repository mirrors
         # POM 中配置的国内镜像仓库在 CI 环境不稳定，构建前移除，改用 Maven Central
         run: |
           sed -i.bak '/<repositories>/,/<\/repositories>/d' pom.xml
           sed -i.bak '/<pluginRepositories>/,/<\/pluginRepositories>/d' pom.xml
       - name: Set up JDK 17
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy Server
 
 on:
   # 推送时执行
@@ -17,7 +17,7 @@ jobs:
     steps:
       # 1、检出源码
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # 2、移除 POM 中的国内镜像仓库（CI 环境不稳定）
       - name: Remove repository mirrors
         run: |
@@ -25,7 +25,7 @@ jobs:
           sed -i.bak '/<pluginRepositories>/,/<\/pluginRepositories>/d' pom.xml
       # 3、安装 Java 环境
       - name: Setup Java
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: 17
           distribution: temurin

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,8 @@ permissions:
   contents: read
 
 jobs:
-  deploy-server:
+  deploy:
+    name: Deploy server
     runs-on: ubuntu-latest
     steps:
       # 1、检出源码
@@ -34,7 +35,7 @@ jobs:
         run: ./mvnw -B package
       # 5、拷贝到服务器
       - name: Copy
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@917f8b81dfc1ccd331fef9e2d61bdc6c8be94634 # v0.1.7
         with:
           host: ${{ secrets.SERVER_HOST }}
           port: ${{ secrets.SERVER_PORT }}
@@ -45,7 +46,7 @@ jobs:
           strip_components: 3
       # 6、启动
       - name: Start
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.SERVER_HOST }}
           port: ${{ secrets.SERVER_PORT }}

--- a/.github/workflows/greeting.yml
+++ b/.github/workflows/greeting.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Greet first-time contributor
-        uses: actions/first-interaction@v3
+        uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |-

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -56,7 +56,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check commit authors linked to GitHub
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Sonar 需要完整提交历史用于准确分析
           fetch-depth: 0
@@ -39,13 +39,13 @@ jobs:
           sed -i.bak '/<repositories>/,/<\/repositories>/d' pom.xml
           sed -i.bak '/<pluginRepositories>/,/<\/pluginRepositories>/d' pom.xml
       - name: Set up JDK 17
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: 17
           distribution: temurin
           cache: maven
       - name: Cache SonarQube packages
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/continew-system/src/main/java/top/continew/admin/auth/AbstractLoginHandler.java
+++ b/continew-system/src/main/java/top/continew/admin/auth/AbstractLoginHandler.java
@@ -99,16 +99,13 @@ public abstract class AbstractLoginHandler<T extends LoginReq> implements LoginH
         Long tenantId = TenantContextHolder.getTenantId();
         CompletableFuture<Set<String>> permissionFuture = CompletableFuture.supplyAsync(() -> {
             Set<String> permissions = new HashSet<>();
-            TenantUtils.execute(tenantId, () -> {
-                permissions.addAll(roleService.listPermissionByUserId(userId));
-            });
+            TenantUtils.execute(tenantId,
+                () -> permissions.addAll(roleService.listPermissionByUserId(userId)));
             return permissions;
         }, threadPoolTaskExecutor);
         CompletableFuture<Set<RoleContext>> roleFuture = CompletableFuture.supplyAsync(() -> {
             Set<RoleContext> roles = new HashSet<>();
-            TenantUtils.execute(tenantId, () -> {
-                roles.addAll(roleService.listByUserId(userId));
-            });
+            TenantUtils.execute(tenantId, () -> roles.addAll(roleService.listByUserId(userId)));
             return roles;
         }, threadPoolTaskExecutor);
         CompletableFuture<Integer> passwordExpirationDaysFuture =

--- a/continew-system/src/main/java/top/continew/admin/system/config/file/FileRecorderImpl.java
+++ b/continew-system/src/main/java/top/continew/admin/system/config/file/FileRecorderImpl.java
@@ -76,7 +76,7 @@ public class FileRecorderImpl implements FileRecorder {
         }
         FileDO file = new FileDO(fileInfo);
         file.setStorageId(storage.getId());
-        fileMapper.insert(file);
+        boolean saved = fileMapper.insert(file) > 0;
         fileInfo.setFileId(String.valueOf(file.getId()));
         if (!URLUtils.isHttpUrl(fileInfo.getUrl())) {
             String prefix = storage.getUrlPrefix();
@@ -88,7 +88,7 @@ public class FileRecorderImpl implements FileRecorder {
                     URLUtil.normalize(prefix + fileInfo.getThumbnailPath(), false, true));
             }
         }
-        return true;
+        return saved;
     }
 
     @Override

--- a/continew-system/src/main/java/top/continew/admin/system/controller/UserMessageController.java
+++ b/continew-system/src/main/java/top/continew/admin/system/controller/UserMessageController.java
@@ -89,9 +89,10 @@ public class UserMessageController {
     @GetMapping("/{id}")
     public MessageDetailResp getMessage(@PathVariable Long id) {
         MessageDetailResp detail = messageService.get(id);
+        CheckUtils.throwIfNull(detail, "消息不存在或无权限访问");
         CheckUtils.throwIf(
-            detail == null || (NoticeScopeEnum.USER.equals(detail.getScope()) && !CollUtil
-                .contains(detail.getUsers(), UserContextHolder.getUserId().toString())),
+            NoticeScopeEnum.USER.equals(detail.getScope()) && !CollUtil
+                .contains(detail.getUsers(), UserContextHolder.getUserId().toString()),
             "消息不存在或无权限访问");
         messageService.readMessage(Collections.singletonList(id), UserContextHolder.getUserId());
         detail.setIsRead(true);

--- a/continew-system/src/main/java/top/continew/admin/system/service/impl/DeptServiceImpl.java
+++ b/continew-system/src/main/java/top/continew/admin/system/service/impl/DeptServiceImpl.java
@@ -43,6 +43,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * 部门业务实现
@@ -212,10 +214,13 @@ public class DeptServiceImpl
             return;
         }
         List<DeptDO> list = new ArrayList<>(children.size());
+        // 祖级路径按字面量匹配，正则在循环外编译一次复用，避免每次迭代重复编译
+        Pattern oldAncestorPattern = Pattern.compile(oldAncestors, Pattern.LITERAL);
         for (DeptDO child : children) {
             DeptDO dept = new DeptDO();
             dept.setId(child.getId());
-            dept.setAncestors(child.getAncestors().replaceFirst(oldAncestors, newAncestors));
+            Matcher matcher = oldAncestorPattern.matcher(child.getAncestors());
+            dept.setAncestors(matcher.replaceFirst(Matcher.quoteReplacement(newAncestors)));
             list.add(dept);
         }
         baseMapper.updateById(list);

--- a/continew-system/src/main/java/top/continew/admin/system/service/impl/RoleMenuServiceImpl.java
+++ b/continew-system/src/main/java/top/continew/admin/system/service/impl/RoleMenuServiceImpl.java
@@ -28,7 +28,6 @@ import top.continew.starter.data.service.impl.ServiceImpl;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * 角色和菜单业务实现
@@ -51,7 +50,7 @@ public class RoleMenuServiceImpl extends ServiceImpl<RoleMenuMapper, RoleMenuDO>
             .list()
             .stream()
             .map(RoleMenuDO::getMenuId)
-            .collect(Collectors.toList());
+            .toList();
         if (CollUtil.isEmpty(CollUtil.disjunction(menuIds, oldMenuIdList))) {
             return false;
         }


### PR DESCRIPTION
## 变更类型

- [x] 问题修复（fix）

## 变更目的

#223 合并后，SonarCloud 切换到 CI 全量分析（规则集与之前的 Automatic Analysis 不同），dev 整体分析新浮出 12 个问题：可靠性评级 C（1 bug）、安全评级 C（3 漏洞）。本 PR 修复其中影响评级的问题及易处理的代码异味。

## 解决方案

**可靠性 / 安全（影响评级）**
- **S2259（Bug，NPE）**：`UserMessageController.getMessage` 将空值判断与权限判断合并在 `||` 中，消息不存在时短路后仍解引用。拆分为 `throwIfNull` 空值断言 + 权限判断。
- **S7637×3（漏洞，供应链）**：第三方 GitHub Action 固定为完整 commit SHA，避免 tag/branch 漂移或被替换：
  - `amannn/action-semantic-pull-request` → v6.1.1
  - `appleboy/scp-action` → v0.1.7
  - `appleboy/ssh-action`：`@master` 固定到稳定版 v1.2.5

**代码异味**
- S3516：`FileRecorderImpl.save` 正常落库路径返回 `insert` 实际结果，不再恒定返回 `true`（两个"有意跳过"分支保留）。
- S9142：`DeptServiceImpl` 祖级替换正则在循环外编译为 `Pattern` 复用，并按字面量匹配（`LITERAL` + `quoteReplacement`），避免特殊字符被当作正则。
- S6204：`Collectors.toList()` → `Stream.toList()`（下游只读）。
- S1602：移除单语句 lambda 的无用花括号。

**暂不处理（不影响评级，风险/收益不划算）**
- S2143×2（INFO）：`LogMapper`/`DashboardServiceImpl` 使用旧 `java.util.Date`，迁移到 `java.time` 牵涉 mapper 签名、XML 与调用方，建议单独评估。
- S1135（INFO）：`MultipartUploadConstants` 中的 TODO 为有意保留的待办跟踪。

## 测试情况

- 本地 `./mvnw verify` 四道门禁（Enforcer / Spotless / Checkstyle / SpotBugs）全部通过。
- 预期 SonarCloud 可靠性、安全评级回到 A（新增代码与整体）。

## Changelog

| 模块 | Changelog | Related issues |
|------|-----------|----------------|
| continew-system | 修复消息查询 NPE、文件记录返回值、正则重复编译等 | - |
| CI | 第三方 action 固定完整 SHA | - |

## 提交前确认

- [x] 本地 `./mvnw verify` 四道门禁全部通过
- [x] commit message 符合 Conventional Commits
- [x] AI 生成改动已添加 `Assisted-by: ZCode`
- [x] 目标分支为 `dev`
